### PR TITLE
Make the default aerospike clustering protocol multicast

### DIFF
--- a/aerospike.conf
+++ b/aerospike.conf
@@ -17,13 +17,10 @@ logging {
 	# Log file must be an absolute path.
 	file /var/log/aerospike/aerospike.log {
 		context any info
+		context ldt info
+		context udf detail
 		context query detail
 		context scan detail
-	}
-
-	# Send log messages to stdout
-	console {
-		context any info 
 	}
 }
 
@@ -40,13 +37,9 @@ network {
 	}
 
 	heartbeat {
-
-		# mesh is used for environments that do not support multicast
-		mode mesh
-		port 3002
-
-		# use asinfo -v 'tip:host=<ADDR>;port=3002' to inform cluster of
-		# other mesh nodes
+		mode multicast
+		multicast-group 239.1.99.4
+		port 9949
 
 		interval 150
 		timeout 10
@@ -66,7 +59,7 @@ namespace CLEAN {
 	memory-size 1G
 	default-ttl 30d # expire/evict after 30 days until pinned explicitly (rec ttl set to 0).
 
-	#	storage-engine memory
+	# storage-engine memory
 
 	# To use file storage backing, comment out the line above and use the
 	# following lines instead.
@@ -83,7 +76,7 @@ namespace DIRTY {
 	memory-size 1G
 	default-ttl 0  # 0 to never expire/evict.
 
-	#	storage-engine memory
+	# storage-engine memory
 
 	# To use file storage backing, comment out the line above and use the
 	# following lines instead.


### PR DESCRIPTION
Making the multicast protocol default for aerospike. Mesh configuration is not working for us.