### PR TITLE
Increase write memory limits for Lite profile

### DIFF
--- a/src/hyc_asd_mgr.py
+++ b/src/hyc_asd_mgr.py
@@ -47,8 +47,8 @@ PWQ_MEMORY_MARKER = "PWQ_MEMORY"
 
 memory_config = {
     "lite" : {
-        "max-write-cache" : 128*1024*1024,
-        "post-write-queue" : 1,
+        "max-write-cache" : 256*1024*1024,
+        "post-write-queue" : 64,
         "memory_per_ns": 3,
         "system" : 1,
     },


### PR DESCRIPTION
On VC setup @sphansalkar  saw ASD timeout issues.

Max Write Cached
- changed to 256 from 128
- this will help absorbing write bursts 

post-write-queue
- changed to 64 from 1
- this will help in partial write, specifically during boot.

Signed-off-by: Prasad Joshi <Prasad.Joshi@primaryio.com>