### PR TITLE
ASD: increase defrag percentage

### DIFF
--- a/aerospike_mesh.conf
+++ b/aerospike_mesh.conf
@@ -73,7 +73,7 @@ namespace CLEAN {
 		PWQ_MEMORY
 		data-in-memory false # Store data in memory in addition to file.
 		write-block-size 1M
-		defrag-lwm-pct 50
+		defrag-lwm-pct 70
 	}
 }
 
@@ -94,6 +94,6 @@ namespace DIRTY {
 		PWQ_MEMORY
 		data-in-memory false # Store data in memory in addition to file.
 		write-block-size 1M
-		defrag-lwm-pct 50
+		defrag-lwm-pct 90
 	}
 }

--- a/aerospike_multicast.conf
+++ b/aerospike_multicast.conf
@@ -66,7 +66,7 @@ namespace CLEAN {
 		PWQ_MEMORY
 		data-in-memory false # Store data in memory in addition to file.
 		write-block-size 1M
-		defrag-lwm-pct 50
+		defrag-lwm-pct 70
 	}
 }
 
@@ -87,6 +87,6 @@ namespace DIRTY {
 		PWQ_MEMORY
 		data-in-memory false # Store data in memory in addition to file.
 		write-block-size 1M
-		defrag-lwm-pct 50
+		defrag-lwm-pct 90
 	}
 }

--- a/src/hyc_asd_mgr.py
+++ b/src/hyc_asd_mgr.py
@@ -55,7 +55,7 @@ memory_config = {
         "dirty-rep-factor" : 1,
     },
     "standard": {
-        "max-write-cache" : 256*1024*1024,
+        "max-write-cache" : 512*1024*1024,
         "post-write-queue" : 256,
         "memory_per_ns": 4,
         "system" : 2,


### PR DESCRIPTION
After the checkpoint is flushed, we go through list of Keys modified
in the checkpoint and issue a delete for all of these keys. The block
is marked for defrag, once the amount of usable data in ssd_write_buf*
decrases beyond some point. If the defrag percet is too low, probablity
of deleting a Key, that is just defragged incrases significantly.

The defrag increase the load on the storage devices. It can quickly
fill the write queue. ASD starts giving OVERLOAD errors, once the write
queue grow beyond certain limit.

Signed-off-by: Prasad Joshi <Prasad.Joshi@primaryio.com>