### PR TITLE
Fix typo in set_health

### DIFF
--- a/src/hyc_asd_mgr.py
+++ b/src/hyc_asd_mgr.py
@@ -404,7 +404,7 @@ class ComponentMgr(Thread):
         while not st:
             log.debug("Waiting for asd service to come up")
             time.sleep(10)
-            self.halib.set_health(False)
+            self.halib.set_health(True)
             st = is_service_avaliable()
 
         self.started = True
@@ -415,7 +415,7 @@ class ComponentMgr(Thread):
                 log.error("service not up!! Retry cnt: %s" %self.failure_retry)
                 self.failure_retry -= 1
                 time.sleep(hb_update_duration)
-                self.halib.set_health(False)
+                self.halib.set_health(True)
                 continue
 
             if (not is_service_avaliable() and self.failure_retry > 0):


### PR DESCRIPTION
Pulling in a missed commit on the original pull request.

BVT run with success.
----------------------------------------------- generated xml file: /root/hyc-test/pio_qa/Results/bvt_results-5386/output.xml -----------------------------------------------
---------------------------------------------- generated html file: /root/hyc-test/pio_qa/Results/bvt_results-5386/report.html ----------------------------------------------
======================================================================== 2 passed in 2732.56 seconds ========================================================================
r

logs are here.
https://drive.google.com/drive/folders/1P46oAwufFmhszP40I_seRPAChXvohexa?usp=sharing